### PR TITLE
chore: 自動生成ファイルをESLintの`ignores`に追加

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,13 @@ export default [
 
   {
     name: 'app/files-to-ignore',
-    ignores: ['**/dist/**', '**/dist-ssr/**', '**/coverage/**'],
+    ignores: [
+      '**/dist/**',
+      '**/dist-ssr/**',
+      '**/coverage/**',
+      'src/lib/apis/generated/**',
+      'public/mockServiceWorker.js',
+    ],
   },
 
   ...pluginVue.configs['flat/essential'],


### PR DESCRIPTION
`src/lib/apis/generated/**`と`public/mockServiceWorker.js`を`eslint.config.js`の`ignores`に追加